### PR TITLE
Add Veracode security pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,5 @@
+// Veracode security scans (SCA + IaC/secrets every build, SAST/Policy on
+// the default branch after a merge). Logic lives in the shared library; this only pins it.
+@Library('veracode-pipeline@v1') _
+
+veracodePipeline()


### PR DESCRIPTION
Adds a 2-line `Jenkinsfile` that invokes the central `veracode-pipeline` shared library. All scan logic lives in the library; this file only pins the version. No build behavior of this repo is changed.